### PR TITLE
add safety wrapper to prevent server crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ bin/
 # fabric
 
 run/
+.DS_Store

--- a/src/main/java/com/fusionflux/portalcubed/mixin/EntityMixin.java
+++ b/src/main/java/com/fusionflux/portalcubed/mixin/EntityMixin.java
@@ -8,12 +8,12 @@ import com.fusionflux.portalcubed.entity.EntityAttachments;
 import com.fusionflux.portalcubed.entity.ExperimentalPortal;
 import com.fusionflux.portalcubed.entity.PortalPlaceholderEntity;
 import com.fusionflux.portalcubed.accessor.CustomCollisionView;
+import com.fusionflux.portalcubed.packet.NetworkingSafetyWrapper;
 import com.fusionflux.portalcubed.sound.PortalCubedSounds;
 import com.fusionflux.portalcubed.util.PortalVelocityHelper;
 import com.google.common.collect.Lists;
 import me.andrew.gravitychanger.api.GravityChangerAPI;
 import me.andrew.gravitychanger.util.RotationUtil;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
@@ -178,7 +178,7 @@ public abstract class EntityMixin implements EntityAttachments, EntityPortalsAcc
             bytebuf.writeDouble(this.getVelocity().getX());
             bytebuf.writeDouble(this.getVelocity().getY());
             bytebuf.writeDouble(this.getVelocity().getZ());
-            ClientPlayNetworking.send(PortalCubed.id("portalpacket"), bytebuf);
+            NetworkingSafetyWrapper.sendFromClient("portalpacket", bytebuf);
         }
 
             List<ExperimentalPortal> list = ((Entity) (Object) this).world.getNonSpectatingEntities(ExperimentalPortal.class, getBoundingBox().stretch(this.getVelocity().multiply(1)));

--- a/src/main/java/com/fusionflux/portalcubed/packet/NetworkingSafetyWrapper.java
+++ b/src/main/java/com/fusionflux/portalcubed/packet/NetworkingSafetyWrapper.java
@@ -1,0 +1,14 @@
+package com.fusionflux.portalcubed.packet;
+
+import com.fusionflux.portalcubed.PortalCubed;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+
+//Because of some Mixin+JVM weird implementation detail bs -
+//gotta have the `ClientPlayNetworking` call in a separate class
+//so that Mixin can resolve all the classes used when patching
+public class NetworkingSafetyWrapper {
+	public static void sendFromClient(String name, PacketByteBuf bytebuf) {
+		ClientPlayNetworking.send(PortalCubed.id(name), bytebuf);
+	}
+}


### PR DESCRIPTION
prevents a weird Mixin/JVM implementation detail crash on servers by adding a wrapper for `ClientPlayNetworking` calls in two-sided Mixins