### PR TITLE
✏ Severely shorten the hash in Artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Get short SHA
+      id: short_sha
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
     - name: Set up JDK 17
       uses: actions/setup-java@v1
@@ -28,5 +32,5 @@ jobs:
     - name: capture build artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: Artifact-${{ github.sha }}
+        name: Artifact-${{steps.short_sha.outputs.sha8}}
         path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     
     - name: Get short SHA
       id: short_sha
-      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-7)"
 
     - name: Set up JDK 17
       uses: actions/setup-java@v1


### PR DESCRIPTION
This PR will make the Artifact hash name not be extremely long, and just be a 7 character hash.

So instead of `Artifact-93c1dd6a9d3d816f47efddc42a37a3badb64f721`, it'll simply be `Artifact-93c1dd6`. This basically is in parity with the JAR name already [which is appropriately named `portal_cubed-2.2.9-rev.93c1dd6.jar`]

![image](https://user-images.githubusercontent.com/99072163/209630795-4245b6bb-73cf-4e09-86a6-fcf028646aa5.png)
